### PR TITLE
DConf2013: Remove empty FAQ section

### DIFF
--- a/2013/Makefile
+++ b/2013/Makefile
@@ -4,7 +4,7 @@ endif
 
 TMP = .tmp
 
-HTML_NAMES = $(addsuffix .html, index contact faq venue registration	\
+HTML_NAMES = $(addsuffix .html, index contact venue registration	\
  schedule/index speakers/index kickstarter/index)
 
 TALK_BASENAMES = alexandrescu bright buclaw cehreli chevalier_boisvert	\

--- a/2013/faq.dd
+++ b/2013/faq.dd
@@ -1,5 +1,0 @@
-Ddoc
-
-$(T h1,, Frequently Asked Questions)
-
-$(P No FAQs so far.)

--- a/2013/macros.ddoc
+++ b/2013/macros.ddoc
@@ -60,7 +60,6 @@ $(DIV class="menu row_after",
       <li><a href="$(BASE)/registration.html">Registration</a></li>
       <li><a href="$(BASE)/speakers/index.html">Speakers</a></li>
       <li><a href="$(BASE)/venue.html">Venue</a></li>
-      <li><a href="$(BASE)/faq.html">FAQ</a></li>
       <li><a href="$(BASE)/contact.html">Contact Us</a></li>
     </ul>
   </nav>


### PR DESCRIPTION
This section should be frozen now, so it will never have a FAQ. Having
an empty section gives the impression of a site under construction,
which usually leaves a bad impression, so is probably better to just
remove this section completely.
