### PR TITLE
Fix URL for Martin's talk slides

### DIFF
--- a/2016/talks/nowak.dd
+++ b/2016/talks/nowak.dd
@@ -18,7 +18,7 @@ TALK_TITLE = Object-Relational Mapper
 
 SLIDES = $(SLIDES_YES)
 
-SLIDES_URL = https://code.dawg.eu/talks/2016-05-06-orm_dconf
+SLIDES_URL = https://code.dawg.eu/talks/2016-05-06-orm_dconf/
 
 SLIDE_LINKS = $(LINK2 $(SLIDES_URL), View online)
 


### PR DESCRIPTION
The existing link doesn't exactly work.