### PR TITLE
Add red top border

### DIFF
--- a/2017/includes/style.css
+++ b/2017/includes/style.css
@@ -29,6 +29,7 @@ hr {
 	left: 0;
 	width: 100%;
 	background: #52255F;
+	border-top: 3px solid #b72a00;
 }
 .logo a
 {


### PR DESCRIPTION
The [DConf16](http://dconf.org/2016/index.html) page had a red header that apparently wasn't copied in the process from converting the image to HTML.
However, if wanted, such a header bar is easy add:

## 0px (currently)

![image](https://cloud.githubusercontent.com/assets/4370550/23537369/d97278d2-ffcb-11e6-8cbe-be89d2d18d36.png)

## 2px (2016)

![image](https://cloud.githubusercontent.com/assets/4370550/23537341/a3c975e6-ffcb-11e6-843a-e0d51e6660f2.png)

## 3px (selected for this PR)

![image](https://cloud.githubusercontent.com/assets/4370550/23537362/cb7c2232-ffcb-11e6-9d98-08d68e724408.png)

## 4px

![image](https://cloud.githubusercontent.com/assets/4370550/23537379/eccc871a-ffcb-11e6-9b8b-fa8137a203e5.png)