### PR TITLE
Deploy automatically with Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 # Generated directories
 /20??/.tmp
 /out
+
+# Private key
+/deploy_rsa

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: d
+addons:
+  apt:
+    sources:
+    # older versions of Make don't support the wildcard rules and will create folders instead of files
+    - make
+script: make
+before_deploy:
+- echo -e "Host digitalmars.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
+- openssl aes-256-cbc -K $encrypted_1daeb42065ec_key -iv $encrypted_1daeb42065ec_iv
+  -in deploy_rsa.enc -out deploy_rsa -d
+- eval "$(ssh-agent -s)"
+- chmod 600 deploy_rsa
+- ssh-add deploy_rsa
+- chmod -R g+w ./out
+deploy:
+- provider: script
+  skip_cleanup: true
+  # Travis supports only "one" script deployment
+  # The chmod is done separately as it will fail for folder & files not owned by travis_ci_dconf
+  script: rsync -vr --delete-after --omit-dir-times out/ travis_ci_dconf@digitalmars.com:/usr/local/www/dconf.org/data && (ssh travis_ci_dconf@digitalmars.com "chmod -R g+w /usr/local/www/dconf.org/data" || true)
+  on:
+    branch: master

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SITE = dconf.org@digitalmars.com:data/
 DMD = dmd
 OUT = out
 
-all: $(OUT)/index.php 2013/all 2014/all 2015/all 2016/all 2017/all
+all: $(OUT)/index.html 2013/all 2014/all 2015/all 2016/all 2017/all
 
 .PHONY: rsync
 rsync : all

--- a/index.html
+++ b/index.html
@@ -1,0 +1,3 @@
+<html>
+<meta http-equiv="refresh" content="0; url=/2017/index.html" />
+</html>

--- a/index.php
+++ b/index.php
@@ -1,3 +1,0 @@
-<?php
-header("Location: 2017/index.html", TRUE, 303);
-exit;


### PR DESCRIPTION
### Remaining tasks

- [x] Fix permissions problems (the subfolders aren't writeable for the `dconf.org` group
- [ ] Replace `deploy_rsa.enc` with one encrypted for `dlang/dconf.org`

This can be done by running

```
travis encrypt-file deploy_rsa --add --debug
```

and replacing the two `openssl` lines on top with the newly inserted ones at the bottom.