### PR TITLE
Fix Makefile for make 3.81

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,4 @@
 language: d
-addons:
-  apt:
-    sources:
-    # older versions of Make don't support the wildcard rules and will create folders instead of files
-    - make
 script: make
 before_deploy:
 - echo -e "Host digitalmars.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config

--- a/2013/Makefile
+++ b/2013/Makefile
@@ -57,8 +57,8 @@ $(OUT)/kickstarter/%.html : macros.ddoc kickstarter/%.dd
 $(OUT)/%.html : macros.ddoc %.dd
 	$(DMD) -c -o- -Df$@ $^
 
-$(OUT)/%/ : %/
-	cp -r $^ $@
-
 $(OUT)/%.pdf : %.pdf
 	cp $^ $@
+
+$(OUT)/%/ : %/
+	cp -r $^ $@

--- a/2014/Makefile
+++ b/2014/Makefile
@@ -51,8 +51,8 @@ $(TMP)/schedule/%.gen.ddoc : macros.ddoc talks/macros.ddoc schedule/fragment.ddo
 $(OUT)/%.html : macros.ddoc %.dd
 	$(DMD) -c -o- -Df$@ $^
 
-$(OUT)/%/ : %/
-	cp -r $^ $@
-
 $(OUT)/%.pdf : %.pdf
 	cp $^ $@
+
+$(OUT)/%/ : %/
+	cp -r $^ $@

--- a/2015/Makefile
+++ b/2015/Makefile
@@ -53,11 +53,11 @@ $(TMP)/schedule/%.gen.ddoc : macros.ddoc talks/macros.ddoc schedule/fragment.ddo
 $(OUT)/%.html : macros.ddoc %.dd
 	$(DMD) -c -o- -Df$@ $^
 
-$(OUT)/%/ : %/
-	cp -r $^ $@
-
 $(OUT)/%.pdf : %.pdf
 	cp $^ $@
 
 $(OUT)/%.zip : %.zip
 	cp $^ $@
+
+$(OUT)/%/ : %/
+	cp -r $^ $@

--- a/2016/Makefile
+++ b/2016/Makefile
@@ -58,9 +58,6 @@ $(TMP)/schedule/%.gen.ddoc : macros.ddoc talks/macros.ddoc schedule/fragment.ddo
 $(OUT)/%.html : macros.ddoc %.dd
 	$(DMD) -c -o- -Df$@ $^
 
-$(OUT)/%/ : %/
-	cp -r $^ $@
-
 $(OUT)/%.pdf : %.pdf
 	cp $^ $@
 
@@ -69,3 +66,6 @@ $(OUT)/%.pptx : %.pptx
 
 $(OUT)/%.zip : %.zip
 	cp $^ $@
+
+$(OUT)/%/ : %/
+	cp -r $^ $@

--- a/2017/Makefile
+++ b/2017/Makefile
@@ -51,9 +51,6 @@ $(TMP)/schedule/%.gen.ddoc : macros.ddoc talks/macros.ddoc schedule/fragment.ddo
 $(OUT)/%.html : macros.ddoc %.dd
 	$(DMD) -c -o- -Df$@ $^
 
-$(OUT)/%/ : %/
-	mkdir -p $@
-
 $(OUT)/%.pdf : %.pdf
 	cp $^ $@
 
@@ -71,3 +68,7 @@ $(OUT)/%.svg : %.svg
 
 $(OUT)/%.css : %.css
 	cp $^ $@
+
+$(OUT)/%/ : %/
+	mkdir -p $@
+


### PR DESCRIPTION
@andralex I found the issue for the problem that you had on your last deploy as it's appearing on Travis as well:

```
mkdir -p ../out/2017/images
mkdir -p ../out/2017/images/heimathafen.png
mkdir -p ../out/2017/images/dconf_logo_2017.svg
mkdir -p ../out/2017/includes
mkdir -p ../out/2017/includes/style.css
```

It is due to an old, and outdated version of `make` which is bundled with Ubuntu 12.04 on Travis.
So I down-graded from my shiny `make`:

```
> make -v
GNU Make 4.2.1
Built for x86_64-pc-linux-gnu
Copyright (C) 1988-2016 Free Software Foundation, Inc.
```

back into the past:

```
> make -v
GNU Make 3.81
Copyright (C) 2006  Free Software Foundation, Inc.
```

and found out that the old `make` simply has troubles with building the dependency graph and one can help manually. FWIW this has been fixed with 3.82.

Earlier I tried to upgrade `make` on Travis, but it seems that `make` can't be upgraded on Travis as it's not whitelisted :/