### PR TITLE
Fix youtube link

### DIFF
--- a/2017/index.dd
+++ b/2017/index.dd
@@ -4,7 +4,7 @@ $(T h1,,DConf 2017$(BR) Bigger, Badder, and Berliner!)
 
 $(T h2,,Please join us at DConf 2017, the international conference of the D programming language in Berlin, Germany, May 4-7 2017.)
 
-$(P DConf 2017 is now underway! If you aren't with us in Berlin, be sure to join us via the livestream at $(HTTP youtube.com/watch?v=MqrJZg6PgnM, YouTube).)
+$(P DConf 2017 is now underway! If you aren't with us in Berlin, be sure to join us via the livestream at $(HTTP youtube.com/user/sociomantic/live, YouTube).)
 
 $(P We're happy to announce that the D Language Foundation is cooperating again with $(HTTP sociomantic.com, Sociomantic) to organize DConf 2017 in Berlin for the second time. Same location, same dates, but of course a whole new experience!)
 


### PR DESCRIPTION
The youtube video ID changes if a live stream is restarted. Use a permanent link instead.

ping @acehreli  @andralex @WalterBright 