### PR TITLE
Use HTTPS for hyphenate.js

### DIFF
--- a/2013/macros.ddoc
+++ b/2013/macros.ddoc
@@ -27,7 +27,7 @@ HEADER =
 $(GETSCRIPT $(BASE)/includes/jquery.min.js)
 $(COMMENT $(GETSCRIPT $(BASE)/includes/css.js))
 $(GETSCRIPT $(BASE)/includes/widget.js)
-$(GETSCRIPT http://dlang.org/js/hyphenate.js)
+$(GETSCRIPT https://dlang.org/js/hyphenate.js)
 <!--[if IE 9]>
 <link rel="stylesheet" type="text/css" href="$(BASE)/includes/iefix.css" />
 <![endif]-->

--- a/2014/macros.ddoc
+++ b/2014/macros.ddoc
@@ -26,7 +26,7 @@ HEADER = <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://
 $(GETSCRIPT $(BASE)/includes/jquery.min.js)
 $(COMMENT $(GETSCRIPT $(BASE)/includes/css.js))
 $(GETSCRIPT $(BASE)/includes/widget.js)
-$(GETSCRIPT http://dlang.org/js/hyphenate.js)
+$(GETSCRIPT https://dlang.org/js/hyphenate.js)
 <!--[if IE 9]>
 <link rel="stylesheet" type="text/css" href="$(BASE)/includes/iefix.css" />
 <![endif]-->

--- a/2015/macros.ddoc
+++ b/2015/macros.ddoc
@@ -28,7 +28,7 @@ HEADER = <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://
 $(GETSCRIPT $(BASE)/includes/jquery.min.js)
 $(COMMENT $(GETSCRIPT $(BASE)/includes/css.js))
 $(GETSCRIPT $(BASE)/includes/widget.js)
-$(GETSCRIPT http://dlang.org/js/hyphenate.js)
+$(GETSCRIPT https://dlang.org/js/hyphenate.js)
 <!--[if IE 9]>
 <link rel="stylesheet" type="text/css" href="$(BASE)/includes/iefix.css" />
 <![endif]-->

--- a/2016/macros.ddoc
+++ b/2016/macros.ddoc
@@ -28,7 +28,7 @@ HEADER = <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://
 $(GETSCRIPT $(BASE)/includes/jquery.min.js)
 $(COMMENT $(GETSCRIPT $(BASE)/includes/css.js))
 $(GETSCRIPT $(BASE)/includes/widget.js)
-$(GETSCRIPT http://dlang.org/js/hyphenate.js)
+$(GETSCRIPT https://dlang.org/js/hyphenate.js)
 <!--[if IE 9]>
 <link rel="stylesheet" type="text/css" href="$(BASE)/includes/iefix.css" />
 <![endif]-->

--- a/2017/macros.ddoc
+++ b/2017/macros.ddoc
@@ -28,7 +28,7 @@ HEADER = <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://
 $(GETSCRIPT $(BASE)/includes/jquery.min.js)
 $(COMMENT $(GETSCRIPT $(BASE)/includes/css.js))
 $(GETSCRIPT $(BASE)/includes/widget.js)
-$(GETSCRIPT http://dlang.org/js/hyphenate.js)
+$(GETSCRIPT https://dlang.org/js/hyphenate.js)
 <!--[if IE 9]>
 <link rel="stylesheet" type="text/css" href="$(BASE)/includes/iefix.css" />
 <![endif]-->


### PR DESCRIPTION
Fixes insecure content warnings when viewing dconf.org through https.