### PR TITLE
Fix youtube links for three talks

### DIFF
--- a/2014/talks/alexandrescu.dd
+++ b/2014/talks/alexandrescu.dd
@@ -22,7 +22,7 @@ SLIDES = $(SLIDES_NO)
 
 VIDEO_URL_A = https://archive.org/details/dconf2014-day01-talk01
 
-VIDEO_URL_Y = http://youtu.be/U580iDBBZQk
+VIDEO_URL_Y = https://youtu.be/tuJ2noqkiSw
 
 VIDEO = $(VIDEO_YES)
 

--- a/2014/talks/allison.dd
+++ b/2014/talks/allison.dd
@@ -18,7 +18,7 @@ TALK_TITLE = A Real D In Programming: Lessons Learned From Eight Years of Teachi
 
 SLIDES = $(SLIDES_NO)
 
-VIDEO_URL_Y = https://www.youtube.com/watch?v=ymoIx3klQ6M
+VIDEO_URL_Y = https://youtu.be/sBjOnSq6tsE
 
 VIDEO_URL_A = https://archive.org/details/dconf2014-day01-talk03
 

--- a/2014/talks/olshansky.dd
+++ b/2014/talks/olshansky.dd
@@ -12,7 +12,7 @@ SPEAKER_URL = https://github.com/blackwhale
 
 SPEAKER_PIC = $(BASE)/../2013/images/DmitryOlshansky.jpg
 
-VIDEO_URL_Y = https://www.youtube.com/watch?v=hkaOciiP11c
+VIDEO_URL_Y = https://youtu.be/RVri2-VJvxI
 
 VIDEO_URL_A = https://archive.org/details/dconf2014-day01-talk04
 


### PR DESCRIPTION
New YouTube links for alexandrescu, allison, and olshansky for DConf 2014 site.