### PR TITLE
[2014] Replace some archive.org links with ustream links

### DIFF
--- a/2014/talks/crapuchettes.dd
+++ b/2014/talks/crapuchettes.dd
@@ -18,7 +18,7 @@ TALK_TITLE = Templates in the Wild: A Postmortem
 
 SLIDES = $(SLIDES_NO)
 
-VIDEO_URL_A = https://archive.org/details/dconf2014-day01-talk02
+VIDEO_URL_A = http://www.ustream.tv/recorded/47930242
 
 VIDEO_URL_Y = https://youtube.com/watch?v=TlqVu9RtoeY
 

--- a/2014/talks/macros.ddoc
+++ b/2014/talks/macros.ddoc
@@ -18,7 +18,7 @@ SLIDES_NO =
 
 SLIDES =
 
-VIDEO_YES = Video:&nbsp;$(T A, href="$(VIDEO_URL_A)",[archive.org])&nbsp;$(T A, href="$(VIDEO_URL_Y)",[youtube])<br />
+VIDEO_YES = Video:&nbsp;$(T A, href="$(VIDEO_URL_Y)",[youtube])&nbsp;$(T A, href="$(VIDEO_URL_A)",[alternative])<br />
 
 DDOC =
 $(HEADER)

--- a/2014/talks/meyers.dd
+++ b/2014/talks/meyers.dd
@@ -22,7 +22,7 @@ SLIDES = $(SLIDES_NO)
 
 VIDEO_URL_Y = http://www.youtube.com/watch?v=48kP_Ssg2eY
 
-VIDEO_URL_A = http://www.youtube.com/watch?v=48kP_Ssg2eY
+VIDEO_URL_A = http://www.ustream.tv/recorded/47947981
 
 VIDEO = $(VIDEO_YES)
 


### PR DESCRIPTION
Replace archive.org links for meyers and crapuchettes with ustream links
Change 'archive.org' label to 'alternative' in macro template, and make YouTube links come first