### PR TITLE
[2014] Update youtube link for Dicebot's talk

### DIFF
--- a/2014/talks/strasuns.dd
+++ b/2014/talks/strasuns.dd
@@ -18,9 +18,9 @@ TALK_TITLE = Declarative programming in D
 
 LEVEL = Basic, Intermediate
 
-VIDEO_URL_Y = http://www.youtube.com/watch?v=SqeOPLB2xAM
+VIDEO_URL_Y = https://www.youtube.com/watch?v=9yI7h-tFRKY
 
-VIDEO_URL_A = https://archive.org/details/dconf2014-day03-talk06
+VIDEO_URL_A = https://www.youtube.com/watch?v=9yI7h-tFRKY
 
 VIDEO = $(VIDEO_YES)
 
@@ -38,12 +38,6 @@ $(T li,, Thoughts about existing issues.)
 )
 
 SLIDES = $(SLIDES_NO)
-
-VIDEO_SD_URL = http://youtube.com/watch?v=
-
-VIDEO_HD_URL = https://archive.org/details/dconf2014-day02-talk02
-
-VIDEO = $(VIDEO_NO)
 
 ABSTRACT =
 When term "declarative programming" is used in context of imperative languages,


### PR DESCRIPTION
Adds an updated YouTube link to the talk, but also points the "alternative" link to the same video -- it's not available on archive.org.