### PR TITLE
Add a workflow to test pull request & deploy to gh-pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+on: [ push, pull_request ]
+
+jobs:
+  main:
+    name: Run
+    runs-on: 'ubuntu-latest'
+    steps:
+      # Uses the latest DMD
+      - uses: dlang-community/setup-dlang@v1
+      - uses: actions/checkout@v2
+      - name: Test
+        run: |
+          make all
+
+      - name: Deploy to Github pages
+        if: github.event_name == 'push'
+        run: |
+          # Remove gh-branch if it already exists, check it out
+          git branch -D gh-pages || true
+          git checkout --orphan gh-pages
+          # Remove all staged files - We only need the docs
+          git rm -rf $(git ls-files)
+          # We can have some leftover files (e.g. build)
+          # So add out (which is only what we need), then `git mv` it.
+          git add out/
+          git mv -k out/* ./
+          # Configure user (because persist-credentials does not persist everything)
+          git config --global user.name  "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+          # We're done
+          git commit -m "Deployment for commit ${{ github.sha }}"
+          git push -f ${{ github.event.repository.clone_url }} gh-pages:gh-pages


### PR DESCRIPTION
In order to move away from Travis-CI, we need to move deployment to Github CI.
However, as a first step, this adds a CI for pull requests and deploy
to Github pages, as this doesn't require the secret to be set up.